### PR TITLE
Support for strandMode in GAlignmentsList objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ biocViews: Infrastructure, DataImport, Genetics, Sequencing, RNASeq, SNP,
 URL: https://bioconductor.org/packages/GenomicAlignments
 Video: https://www.youtube.com/watch?v=2KqBSbkfhRo , https://www.youtube.com/watch?v=3PK_jx44QTs
 BugReports: https://github.com/Bioconductor/GenomicAlignments/issues
-Version: 1.35.1
+Version: 1.35.2
 License: Artistic-2.0
 Encoding: UTF-8
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ biocViews: Infrastructure, DataImport, Genetics, Sequencing, RNASeq, SNP,
 URL: https://bioconductor.org/packages/GenomicAlignments
 Video: https://www.youtube.com/watch?v=2KqBSbkfhRo , https://www.youtube.com/watch?v=3PK_jx44QTs
 BugReports: https://github.com/Bioconductor/GenomicAlignments/issues
-Version: 1.35.0
+Version: 1.35.1
 License: Artistic-2.0
 Encoding: UTF-8
 Authors@R: c(

--- a/R/findOverlaps-methods.R
+++ b/R/findOverlaps-methods.R
@@ -94,7 +94,15 @@ setMethod("findOverlaps", c("GAlignmentsList", "Vector"),
              select = c("all", "first", "last", "arbitrary"),
              ignore.strand = FALSE)
     {
-        hits <- findOverlaps(grglist(unlist(query, use.names = FALSE)),
+        ## to take into account the right (real) strand, when ignore.strand=FALSE,
+        ## we duplicate GAligbnmentsList object in memory and update the original
+        ## strand with the real one, according to the strandMode parameter
+        ## TODO: it may be worth investigating alternative ways to avoid duplicating
+        ## a presumably large GAlignmentsList object
+        query2 <- query
+        if (!ignore.strand)
+          strand(query2) <- strand(query2) ## overwrite original strand w/ real one
+        hits <- findOverlaps(grglist(unlist(query2, use.names=FALSE)),
                              subject, maxgap = maxgap, minoverlap = minoverlap,
                              type = match.arg(type), select = match.arg(select),
                              ignore.strand = ignore.strand)
@@ -112,7 +120,15 @@ setMethod("findOverlaps", c("Vector", "GAlignmentsList"),
              select = c("all", "first", "last", "arbitrary"),
              ignore.strand = FALSE)
     {
-        hits <- findOverlaps(query, grglist(unlist(subject, use.names = FALSE)),
+        ## to take into account the right (real) strand, when ignore.strand=FALSE,
+        ## we duplicate GAligbnmentsList object in memory and update the original
+        ## strand with the real one, according to the strandMode parameter
+        ## TODO: it may be worth investigating alternative ways to avoid duplicating
+        ## a presumably large GAlignmentsList object
+        subject2 <- subject
+        if (!ignore.strand)
+          strand(subject2) <- strand(subject2) ## overwrite original strand w/ real one
+        hits <- findOverlaps(query, grglist(unlist(subject2, use.names = FALSE)),
                              maxgap = maxgap, minoverlap = minoverlap,
                              type = match.arg(type), select = match.arg(select),
                              ignore.strand = ignore.strand)
@@ -130,8 +146,19 @@ setMethod("findOverlaps", c("GAlignmentsList", "GAlignmentsList"),
              select = c("all", "first", "last", "arbitrary"),
              ignore.strand = FALSE)
     {
-        hits <- findOverlaps(grglist(unlist(query, use.names = FALSE)), 
-                             grglist(unlist(subject, use.names = FALSE)),
+        ## to take into account the right (real) strand, when ignore.strand=FALSE,
+        ## we duplicate GAligbnmentsList object in memory and update the original
+        ## strand with the real one, according to the strandMode parameter
+        ## TODO: it may be worth investigating alternative ways to avoid duplicating
+        ## a presumably large GAlignmentsList object
+        query2 <- query
+        subject2 <- subject
+        if (!ignore.strand) {
+          strand(query2) <- strand(query2) ## overwrite original strand w/ real one
+          strand(subject2) <- strand(subject2) ## overwrite original strand w/ real one
+        }
+        hits <- findOverlaps(grglist(unlist(query2, use.names = FALSE)), 
+                             grglist(unlist(subject2, use.names = FALSE)),
                              maxgap = maxgap, minoverlap = minoverlap,
                              type = match.arg(type), 
                              select = match.arg(select),

--- a/R/readGAlignments.R
+++ b/R/readGAlignments.R
@@ -290,11 +290,12 @@ setMethod("readGAlignmentPairs", "character",
 
 setGeneric("readGAlignmentsList", signature="file",
     function(file, index=file, use.names=FALSE, param=ScanBamParam(),
-                   with.which_label=FALSE)
+                   with.which_label=FALSE, strandMode=1)
         standardGeneric("readGAlignmentsList")
 )
 
-.matesFromBam <- function(file, use.names, param, what0, with.which_label)
+.matesFromBam <- function(file, use.names, param, what0, with.which_label,
+                          strandMode)
 {
     bamcols <- .load_bamcols_from_BamFile(file, param, what0,
                                           with.which_label=with.which_label)
@@ -302,7 +303,10 @@ setGeneric("readGAlignmentsList", signature="file",
     gal <- GAlignments(seqnames=bamcols$rname, pos=bamcols$pos,
                        cigar=bamcols$cigar, strand=bamcols$strand,
                        seqlengths=seqlengths)
-    gal <- .bindExtraData(gal, use.names=FALSE, param, bamcols,
+    flag0 <- scanBamFlag()
+    what0 <- "flag"
+    param2 <- .normargParam(param, flag0, what0)
+    gal <- .bindExtraData(gal, use.names=FALSE, param2, bamcols,
                           with.which_label=with.which_label)
     if (asMates(file)) {
         f <- factor(bamcols$groupid)
@@ -315,35 +319,37 @@ setGeneric("readGAlignmentsList", signature="file",
     }
     if (use.names)
         names(gal) <- unique(splitAsList(bamcols$qname, bamcols$groupid))
+    strandMode(gal) <- strandMode
     gal
 }
 
 .readGAlignmentsList.BamFile <- function(file, index=file,
                                          use.names=FALSE, param=ScanBamParam(),
-                                         with.which_label=FALSE)
+                                         with.which_label=FALSE, strandMode=1)
 {
     if (!isTRUEorFALSE(use.names))
         stop("'use.names' must be TRUE or FALSE")
     if (!asMates(file))
         bamWhat(param) <- setdiff(bamWhat(param), 
                                   c("groupid", "mate_status"))
-    what0 <- c("rname", "strand", "pos", "cigar", "groupid", "mate_status")
+    what0 <- c("rname", "strand", "pos", "cigar", "groupid", "mate_status", "flag")
     if (use.names)
         what0 <- c(what0, "qname")
-    .matesFromBam(file, use.names, param, what0, with.which_label)
+    .matesFromBam(file, use.names, param, what0, with.which_label, strandMode)
 }
 
 setMethod("readGAlignmentsList", "BamFile", .readGAlignmentsList.BamFile)
 
 setMethod("readGAlignmentsList", "character",
     function(file, index=file, use.names=FALSE, param=ScanBamParam(),
-                   with.which_label=FALSE)
+                   with.which_label=FALSE, strandMode=1)
     {
         bam <- .open_BamFile(file, index=index, asMates=TRUE, param=param)
         on.exit(close(bam))
         readGAlignmentsList(bam, character(0),
                             use.names=use.names, param=param,
-                            with.which_label=with.which_label)
+                            with.which_label=with.which_label,
+                            strandMode=strandMode)
     }
 )
 

--- a/inst/unitTests/test_readGAlignmentsList.R
+++ b/inst/unitTests/test_readGAlignmentsList.R
@@ -51,7 +51,7 @@ test_readGAlignmentsList_mcols <- function()
     bf <- BamFile(chr4, asMates=TRUE, yieldSize=100)
     param <- ScanBamParam(tag=("NM"))
     galist <- readGAlignmentsList(bf, param=param)
-    checkIdentical(colnames(mcols(unlist(galist))), "NM")
+    checkIdentical(colnames(mcols(unlist(galist))), c("flag", "NM"))
     checkTrue(names(mcols(galist)) == "mate_status")
 
     param <- ScanBamParam(tag=("FO"))
@@ -181,4 +181,19 @@ test_readGAlignmentsList_which <- function()
     checkTrue(all(rng1 %in% my_ROI_labels[1]))
     rng2 <- as.vector(mcols(unlist(target1[2]))$which_label)
     checkTrue(all(rng2 %in% my_ROI_labels[4]))
+}
+
+text_readGAlignmentsList_findOverlaps <- function()
+{
+    fl <- system.file("extdata", "ex1.bam", package="Rsamtools")
+    bf <- BamFile(fl, asMates=TRUE)
+    galist <- readGAlignmentsList(bf, strandMode=1L)
+    f <- GRanges(seqnames="seq1", IRanges(30, 250), strand="-")
+    ov <- findOverlaps(galist[1], f, ignore.strand=FALSE)
+    checkIdentical(0L, length(ov))
+
+    galist <- readGAlignmentsList(bf, strandMode=2L)
+    f <- GRanges(seqnames="seq1", IRanges(30, 250), strand="-")
+    ov <- findOverlaps(galist[1], f, ignore.strand=FALSE)
+    checkIdentical(1L, length(ov))
 }

--- a/man/GAlignmentsList-class.Rd
+++ b/man/GAlignmentsList-class.Rd
@@ -5,6 +5,7 @@
 \alias{class:GAlignmentsList}
 \alias{GAlignmentsList-class}
 \alias{GAlignmentsList}
+\alias{updateObject,GAlignmentsList-method}
 
 % Constructors:
 \alias{GAlignmentsList}

--- a/man/GAlignmentsList-class.Rd
+++ b/man/GAlignmentsList-class.Rd
@@ -26,6 +26,9 @@
 \alias{elementMetadata<-,GAlignmentsList-method}
 \alias{seqinfo,GAlignmentsList-method}
 \alias{seqinfo<-,GAlignmentsList-method}
+\alias{strandMode,GAlignmentsList-method}
+\alias{strandMode<-,GAlignmentsList-method}
+\alias{invertStrand,GAlignmentsList-method}
 
 % Coercion:
 \alias{ranges,GAlignmentsList-method}

--- a/man/readGAlignments.Rd
+++ b/man/readGAlignments.Rd
@@ -34,7 +34,8 @@ readGAlignmentPairs(file, index=file, use.names=FALSE, param=NULL,
                           with.which_label=FALSE, strandMode=1)
 
 readGAlignmentsList(file, index=file, use.names=FALSE,
-                          param=ScanBamParam(), with.which_label=FALSE)
+                          param=ScanBamParam(), with.which_label=FALSE,
+                          strandMode=1)
 
 readGappedReads(file, index=file, use.names=FALSE, param=NULL,
                       with.which_label=FALSE)
@@ -103,7 +104,8 @@ readGappedReads(file, index=file, use.names=FALSE, param=NULL,
     represented as a factor-\link[S4Vectors]{Rle}.
   }
   \item{strandMode}{
-    Strand mode to set on the returned \link{GAlignmentPairs} object.
+    Strand mode to set on the returned \link{GAlignmentPairs} or
+    \link{GAlignmentsList} object.
     See \code{?\link{strandMode}} for more information.
   }
 }


### PR DESCRIPTION
Hi,

This PR provides support for using the `strandMode` parameter with `GAlignmentsList` objects, following our discussion at the [Bioconductor support site](https://support.bioconductor.org/p/9149189). In principle, I've made all necessary edits in the code and in the documentation, and added a unit test in `inst/unitTests/test_readGAlignmentsList.R`. I've tested that the package builds and checks without errors and without warnings caused by this PR.

I've tried to mimic where possible the implementation of `strandMode` for `GAlignmentPairs` object, but there's the following important difference. In `GAlignmentPairs` objects, there is a `GAlignments` object for each mate of a paired alignment, stored in the slots `first` and `last`. This implicitly stores the information about which mate is first and which is not. In the case of `GAlignmentsList` objects, each pair of aligned reads, or set of ambiguously paired aligned reads, is stored as an element of a `CompressedRangesList` object, and therefore, we need to additionally store which aligned read is the first mate, and which is not the first mate. This information is in the `flag` metadata, so the current implementation reads that metadata column from the BAM file and uses it to figure out the "real" strand of each mate, according to the `strandMode` parameter, in a modified `strand()` method. The other key point of the implementation is in the new `findOverlaps()` methods for `GAlignmentsList` objects, which prior to calculating the overlaps, they need to create a new version of the input `GAlignmentsList` object with the real strand according to the `strandMode` parameter. This is done by instructions similar to this one:

```
query2 <- query
strand(query2) <- strand(query2)
```
and perform the `findOverlaps()` operation on the new version `query2` of the `GAlingmentsList` object. This has the consequence of increasing the memory footprint, first because we're storing the `flag` information (an integer vector), and second because in the `findOverlaps()` operation we are duplicating the `GAlignmentsList` object. Probably there's a more efficient way of implementing this, but I couldn't come up with anything better. In any case, the current solution at least calculates the overlaps correctly according to the real strand of the aligned reads, which I think is very important.