### PR TITLE
Addition of the strandMode parameter to readGAlignmentsList()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ biocViews: Infrastructure, DataImport, Genetics, Sequencing, RNASeq, SNP,
 URL: https://bioconductor.org/packages/GenomicAlignments
 Video: https://www.youtube.com/watch?v=2KqBSbkfhRo , https://www.youtube.com/watch?v=3PK_jx44QTs
 BugReports: https://github.com/Bioconductor/GenomicAlignments/issues
-Version: 1.35.0
+Version: 1.35.1
 License: Artistic-2.0
 Encoding: UTF-8
 Authors@R: c(

--- a/inst/unitTests/test_readGAlignmentsList.R
+++ b/inst/unitTests/test_readGAlignmentsList.R
@@ -182,3 +182,18 @@ test_readGAlignmentsList_which <- function()
     rng2 <- as.vector(mcols(unlist(target1[2]))$which_label)
     checkTrue(all(rng2 %in% my_ROI_labels[4]))
 }
+
+text_readGAlignmentsList_findOverlaps <- function()
+{
+    fl <- system.file("extdata", "ex1.bam", package="Rsamtools")
+    bf <- BamFile(fl, asMates=TRUE)
+    galist <- readGAlignmentsList(bf, strandMode=1L)
+    f <- GRanges(seqnames="seq1", IRanges(30, 250), strand="-")
+    ov <- findOverlaps(galist[1], f, ignore.strand=FALSE)
+    checkIdentical(0L, length(ov))
+
+    galist <- readGAlignmentsList(bf, strandMode=2L)
+    f <- GRanges(seqnames="seq1", IRanges(30, 250), strand="-")
+    ov <- findOverlaps(galist[1], f, ignore.strand=FALSE)
+    checkIdentical(1L, length(ov))
+}

--- a/man/readGAlignments.Rd
+++ b/man/readGAlignments.Rd
@@ -34,7 +34,8 @@ readGAlignmentPairs(file, index=file, use.names=FALSE, param=NULL,
                           with.which_label=FALSE, strandMode=1)
 
 readGAlignmentsList(file, index=file, use.names=FALSE,
-                          param=ScanBamParam(), with.which_label=FALSE)
+                          param=ScanBamParam(), with.which_label=FALSE,
+                          strandMode=1)
 
 readGappedReads(file, index=file, use.names=FALSE, param=NULL,
                       with.which_label=FALSE)

--- a/man/readGAlignments.Rd
+++ b/man/readGAlignments.Rd
@@ -35,7 +35,7 @@ readGAlignmentPairs(file, index=file, use.names=FALSE, param=NULL,
 
 readGAlignmentsList(file, index=file, use.names=FALSE,
                           param=ScanBamParam(), with.which_label=FALSE,
-                          strandMode=1)
+                          strandMode=NA)
 
 readGappedReads(file, index=file, use.names=FALSE, param=NULL,
                       with.which_label=FALSE)
@@ -104,8 +104,12 @@ readGappedReads(file, index=file, use.names=FALSE, param=NULL,
     represented as a factor-\link[S4Vectors]{Rle}.
   }
   \item{strandMode}{
-    Strand mode to set on the returned \link{GAlignmentPairs} object.
-    See \code{?\link{strandMode}} for more information.
+    Strand mode to set on the returned \link{GAlignmentPairs} or
+    \link{GAlignmentsList} object. Note that the default value for
+    this parameter is different for \code{readGAlignmentPairs()} and
+    \code{readGAlignmentsList()}.
+    See details below on \code{readGAlignmentsList()} and
+    \code{?\link{strandMode}} for more information.
   }
 }
 
@@ -155,6 +159,12 @@ readGappedReads(file, index=file, use.names=FALSE, param=NULL,
           must be set, otherwise the data are treated as single-end reads. 
           See the \sQuote{asMates} section of \code{?\link[Rsamtools]{BamFile}}
           in the \pkg{Rsamtools} package for details. 
+
+          Note that, by default, \code{strandMode=NA}, which is different to
+          the default value in \code{readGAlignmentPairs()} and which implies
+          that, by default, the strand values in the returned
+          \code{GAlignmentsList} object correspond to the original strand of
+          the reads.
 
     \item \code{readGappedReads} reads a file containing aligned reads as a
           \link{GappedReads} object. See \code{?\link{GappedReads}} for a
@@ -399,7 +409,19 @@ readGAlignmentsList(bamfile)
 ## Use a 'param' to fine tune the results.
 param <- ScanBamParam(flag=scanBamFlag(isProperPair=TRUE))
 galist2 <- readGAlignmentsList(bam, param=param)
+galist2[1:3]
 length(galist2)
+table(elementNROWS(galist2))
+
+## For paired-end data, we can set the 'strandMode' parameter to
+## infer the strand of a pair from the strand of the first and
+## last alignments in the pair
+galist3 <- readGAlignmentsList(bam, param=param, strandMode=0)
+galist3[1:3]
+galist4 <- readGAlignmentsList(bam, param=param, strandMode=1)
+galist4[1:3]
+galist5 <- readGAlignmentsList(bam, param=param, strandMode=2)
+galist5[1:3]
 
 ## ---------------------------------------------------------------------
 ## D. COMPARING 4 STRATEGIES FOR LOADING THE ALIGNMENTS THAT OVERLAP


### PR DESCRIPTION
Following our discussion in this other [PR](https://github.com/Bioconductor/GenomicAlignments/pull/25), this PR adds the parameter `strandMode` to the function `readGAlignmentsList()`, which returns a `GAlignmentsList` object with the real strand calculated according to the `strandMode` argument. This fixes the call to `summarizeOverlaps(..., fragments=TRUE)`, so that it gives correct results and, more generally, it fixes the use of `findOverlaps()` with `GAlignmentsList` objects obtained with this new version of the `readGAlignmentsList()` function. However, `findOverlaps()` will still give the wrong result for any previously serialized `GAlignmentsList` objects and, because the `strandMode` is not stored in the object, the following functionality will differ with respect to `GAlignmentPairs` objects:

* the `strandMode` used to create the `GAlignmentsList` object cannot be displayed through the `show()` method.
* the original strand of the internal `GAlignment` objects is lost.
* the `strandMode` cannot be changed after reading the object.
* the coercion method from `GAlignmentsList` to `GAlignmentPairs` will produce a `GAlignmentPairs` object with the wrong strand, since `GAlignmentPairs` objects store the original strand, but now `GAlignmentsList` objects will only have the real strand.
