### PR TITLE
Bugfix in isCompatibleWithSkippedExons() for single-end read alignments w/ more than 3 junctions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ biocViews: Infrastructure, DataImport, Genetics, Sequencing, RNASeq, SNP,
 URL: https://bioconductor.org/packages/GenomicAlignments
 Video: https://www.youtube.com/watch?v=2KqBSbkfhRo , https://www.youtube.com/watch?v=3PK_jx44QTs
 BugReports: https://github.com/Bioconductor/GenomicAlignments/issues
-Version: 1.39.1
+Version: 1.39.0
 License: Artistic-2.0
 Encoding: UTF-8
 Authors@R: c(

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ biocViews: Infrastructure, DataImport, Genetics, Sequencing, RNASeq, SNP,
 URL: https://bioconductor.org/packages/GenomicAlignments
 Video: https://www.youtube.com/watch?v=2KqBSbkfhRo , https://www.youtube.com/watch?v=3PK_jx44QTs
 BugReports: https://github.com/Bioconductor/GenomicAlignments/issues
-Version: 1.39.0
+Version: 1.39.1
 License: Artistic-2.0
 Encoding: UTF-8
 Authors@R: c(

--- a/R/encodeOverlaps-methods.R
+++ b/R/encodeOverlaps-methods.R
@@ -381,12 +381,15 @@ setGeneric("isCompatibleWithSkippedExons", signature="x",
         stop("only 'max.skipped.exons=NA' is supported for now, sorry")
 
     ## Subpattern for single-end reads.
-    skipped_exons_subpatterns <- c(":(.:)*", ":(..:)*",
-                                   ":(...:)*", ":(....:)*")
+    ## skipped_exons_subpatterns <- c(":(.:)*", ":(..:)*",
+    ##                                ":(...:)*", ":(....:)*")
+    skipped_exons_subpatterns <- function(n)
+                                   paste0(":(", strrep(".", n + 1L), ":)*")
     subpattern1 <- sapply(0:max.njunc1,
                      function(njunc)
                        paste0(build_compatible_encoding_subpatterns(njunc),
-                              collapse=skipped_exons_subpatterns[njunc+1L]))
+                              collapse=skipped_exons_subpatterns(njunc)))
+                              ## collapse=skipped_exons_subpatterns[njunc+1L]))
     subpattern1 <- paste0(":(", paste0(subpattern1, collapse="|"), "):")
 
     ## Subpattern for paired-end reads.

--- a/R/encodeOverlaps-methods.R
+++ b/R/encodeOverlaps-methods.R
@@ -381,15 +381,12 @@ setGeneric("isCompatibleWithSkippedExons", signature="x",
         stop("only 'max.skipped.exons=NA' is supported for now, sorry")
 
     ## Subpattern for single-end reads.
-    ## skipped_exons_subpatterns <- c(":(.:)*", ":(..:)*",
-    ##                                ":(...:)*", ":(....:)*")
     skipped_exons_subpatterns <- function(n)
                                    paste0(":(", strrep(".", n + 1L), ":)*")
     subpattern1 <- sapply(0:max.njunc1,
                      function(njunc)
                        paste0(build_compatible_encoding_subpatterns(njunc),
                               collapse=skipped_exons_subpatterns(njunc)))
-                              ## collapse=skipped_exons_subpatterns[njunc+1L]))
     subpattern1 <- paste0(":(", paste0(subpattern1, collapse="|"), "):")
 
     ## Subpattern for paired-end reads.


### PR DESCRIPTION
Single-end read alignments with more than 3 junctions in the cigar string cause the following error:

```
suppressPackageStartupMessages(library(GenomicAlignments))
suppressPackageStartupMessages(library(TxDb.Hsapiens.UCSC.hg38.knownGene))

txdb <- TxDb.Hsapiens.UCSC.hg38.knownGene
tx <- exonsBy(txdb, by="tx")
aln <- GAlignments("chr1", pos=42837180L, cigar="5S11M1710N21M1111N21M98N27M91N16M",
                   strand("+"), names="read1")
ovtx <- findOverlaps(GRanges(aln), tx, ignore.strand=FALSE)
ovtxenc <- encodeOverlaps(grglist(aln), tx, hits=ovtx,
                          flip.query.if.wrong.strand=FALSE)
maskskpovtx <- isCompatibleWithSkippedExons(ovtxenc) # error
Error in paste0(build_compatible_encoding_subpatterns(njunc), collapse = skipped_exons_subpatterns[njunc +  : 
  invalid 'collapse' argument
```
The error is caused by the following lines in the function `.build_CompatibleWithSkippedExons_pattern0()` from file `encodeOverlaps-methods.R`:

```
    ## Subpattern for single-end reads.
    skipped_exons_subpatterns <- c(":(.:)*", ":(..:)*",
                                   ":(...:)*", ":(....:)*")
    subpattern1 <- sapply(0:max.njunc1,
                     function(njunc)
                       paste0(build_compatible_encoding_subpatterns(njunc),
                              collapse=skipped_exons_subpatterns[njunc+1L]))
```
where `skipped_exons_subpatterns` is a literal vector with 4 values, which are accessed depending on the value `njunc+1L`, where `njunc` is the number of junctions in the cigar string of a single-end read alignment. When `njunc > 3`, then `njunc+1L >= 5`, this position does not exist in `skipped_exons_subpatterns` and the parameter `collapse` gets an `NA` value, causing the `invalid 'collapse' argument` error.

We (Bea Calvo and me) are submitting a fix with this PR, which consists of turning the vector `skipped_exons_subpatterns` into the following function:

```
    skipped_exons_subpatterns <- function(n)
                                   paste0(":(", strrep(".", n + 1L), ":)*")
```
which generates the sought pattern for any number of junctions, e.g.:

```
> skipped_exons_subpatterns(0)
[1] ":(.:)*"
> skipped_exons_subpatterns(1)
[1] ":(..:)*"
> skipped_exons_subpatterns(5)
[1] ":(......:)*"
> skipped_exons_subpatterns(6)
[1] ":(.......:)*"
```