### PR TITLE
Fix of mapToAlignments emitting extra ranges for mapping to the skipped positions at start

### DIFF
--- a/inst/unitTests/test_coordinate-mapping-methods.R
+++ b/inst/unitTests/test_coordinate-mapping-methods.R
@@ -10,6 +10,10 @@ align2 <- GAlignments(rep("chr1", 6), rep(10L, 6), cigar, strand(rep("+", 6)))
 align3 <- GAlignments(rep("chr1", 6), rep(20L, 6), cigar, strand(rep("+", 6)))
 names(align2) <- names(align3) <- letters[1:6]
 
+x2bis <- GRanges("chr1", IRanges(1:6, width=1, names=LETTERS[1:6]))
+align2bis <- GAlignments("chr1", 2L,  cigar = "1S2M1S", strand("+"))
+names(align2bis) = letters[1]
+
 test_mapToAlignments <- function() {
     ans <- mapToAlignments(x1, align1)
     checkIdentical(start(ans), rep(1L, 3))
@@ -22,6 +26,11 @@ test_mapToAlignments <- function() {
     ans <- mapToAlignments(x2, align3)
     checkIdentical(end(ans), c(7L, 4L, 4L, 8L, 6L, 6L)) 
     checkIdentical(mcols(ans)$alignmentsHits, as.integer(1:6))
+
+    ans <- mapToAlignments(x2bis, align2bis)
+    checkIdentical(start(ans), c(2L, 3L))
+    checkIdentical(end(ans), c(2L, 3L))
+    checkIdentical(mcols(ans)$xHits, c(2L, 3L))
 }
 
 test_mapFromAlignments <- function() {

--- a/src/coordinate_mapping_methods.c
+++ b/src/coordinate_mapping_methods.c
@@ -61,7 +61,7 @@ int to_query(int ref_loc, const char *cig0, int pos, Rboolean narrow_left)
     offset += n;
   }
 
-  if (query_loc < 0 || n == 0)
+  if (query_loc <= 0 || n == 0)
     query_loc = NA_INTEGER;
 
   return query_loc;


### PR DESCRIPTION
This is a simple bug in the C code, which assumed 0 instead of 1 based indexing.

`mapToAlignments` emits extra match at the beginning of alignments with S at the start for ranges that is at the skipped position:

```
x2bis <- GRanges("chr1", IRanges(1:6, width=1, names=LETTERS[1:6]))
align2bis <- GAlignments("chr1", 2L,  cigar = "1S2M1S", strand("+"))
names(align2bis) = letters[1]
mapToAlignments(x2bis, align2bis)
```
outputs
```
GRanges object with 3 ranges and 2 metadata columns:
    seqnames    ranges strand |     xHits alignmentsHits
       <Rle> <IRanges>  <Rle> | <integer>      <integer>
  A        a         0      * |         1              1
  B        a         2      * |         2              1
  C        a         3      * |         3              1
  -------
  seqinfo: 1 sequence from an unspecified genome; no seqlengths
```
instead of expected
```
GRanges object with 2 ranges and 2 metadata columns:
    seqnames    ranges strand |     xHits alignmentsHits
       <Rle> <IRanges>  <Rle> | <integer>      <integer>
  B        a         2      * |         2              1
  C        a         3      * |         3              1
  -------
  seqinfo: 1 sequence from an unspecified genome; no seqlengths
```
